### PR TITLE
explicit symbol type of SYMBOL_IGNORING_RPC_RESPONSE_ERROR

### DIFF
--- a/packages/native/src/endpoint.ts
+++ b/packages/native/src/endpoint.ts
@@ -2,7 +2,7 @@ import * as Comlink from "comlink";
 import { RefObject } from "react";
 import WebView, { WebViewMessageEvent } from "react-native-webview";
 
-export const SYMBOL_IGNORING_RPC_RESPONSE_ERROR = Symbol();
+export const SYMBOL_IGNORING_RPC_RESPONSE_ERROR: symbol = Symbol();
 
 export type WebViewEndpoint = Comlink.Endpoint & {
   /**


### PR DESCRIPTION
`unique symbol` type may disturb DTS generation of users' codebase.